### PR TITLE
Use function to construct Normalize component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,6 @@ template {
 }
 `
 
-export const Normalize = createGlobalStyle`${normalize}`
+export const Normalize = createGlobalStyle(normalize);
 
 export default normalize


### PR DESCRIPTION
`css` call returns an array of strings, so we can use function to construct `<Normalize>` component without using tagged template. The result is even smaller bundle size since we can now eliminate the unnecessary helpers generated by babel.

```diff
- function _templateObject() {		
-   var data = _taggedTemplateLiteral(["", ""]);		
-   _templateObject = function _templateObject() {		
-     return data;		
-   };		
-   return data;		
- }		
- function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }		
...
- var Normalize = (0, _styledComponents.createGlobalStyle)(_templateObject(), normalize);
+ var Normalize = (0, _styledComponents.createGlobalStyle)(normalize);
```