### PR TITLE
Add displayName to Normalize component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,5 +151,6 @@ template {
 `
 
 export const Normalize = createGlobalStyle(normalize);
+Normalize.displayName = 'Normalize';
 
 export default normalize


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

React Developer Tool shows the name of the `Normalize` component as `l2`. The PR addresses the issue and assigns a human understandable value to the `displayName` property of the component. As a result we can clearly distinguish the component from other ones with striped out display names. So the debugging process is eased.

<!--do not edit: pr-->
